### PR TITLE
ENG-597 add `MarshalLogObject` methods for `zap`; provide data validation and defaulting

### DIFF
--- a/eventing/eventing_types.go
+++ b/eventing/eventing_types.go
@@ -1,10 +1,14 @@
 package eventing
 
 import (
-	amqp "github.com/rabbitmq/amqp091-go"
-	"go.uber.org/zap"
+	"errors"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // HandlerInvoker is a function type that processes MdaiEvents
@@ -23,6 +27,12 @@ type EventHub struct {
 	connCloseChan chan *amqp.Error
 }
 
+func (h *EventHub) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("queue_name", h.queueName)
+	enc.AddBool("is_listening", h.isListening)
+	return nil
+}
+
 // MdaiEvent represents an event in the system
 type MdaiEvent struct {
 	Id            string    `json:"id,omitempty"`
@@ -32,4 +42,44 @@ type MdaiEvent struct {
 	Source        string    `json:"source"`
 	CorrelationId string    `json:"correlationId,omitempty"`
 	HubName       string    `json:"hubName"`
+}
+
+func (mdaiEvent MdaiEvent) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("name", mdaiEvent.Name)
+	enc.AddString("id", mdaiEvent.Id)
+	enc.AddString("source", mdaiEvent.Source)
+	enc.AddString("hub_name", mdaiEvent.HubName)
+	enc.AddString("payload", mdaiEvent.Payload)
+	enc.AddTime("timestamp", mdaiEvent.Timestamp)
+	enc.AddString("correlation_id", mdaiEvent.CorrelationId)
+	return nil
+}
+
+func (mdaiEvent *MdaiEvent) ApplyDefaults() {
+	if mdaiEvent.Id == "" {
+		mdaiEvent.Id = createEventUuid()
+	}
+	if mdaiEvent.Timestamp.IsZero() {
+		mdaiEvent.Timestamp = time.Now()
+	}
+}
+
+func (mdaiEvent MdaiEvent) Validate() error {
+	if mdaiEvent.Name == "" {
+		return errors.New("missing required field: name")
+	}
+
+	if mdaiEvent.HubName == "" {
+		return errors.New("missing required field: name")
+	}
+
+	if mdaiEvent.Payload == "" {
+		return errors.New("missing required field: name")
+	}
+	return nil
+}
+
+func createEventUuid() string {
+	id := uuid.New()
+	return id.String()
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/decisiveai/mdai-data-core v0.1.4-0.20250522133232-4aa0a4c57198
 	github.com/decisiveai/mdai-operator v0.1.16-0.20250522133829-a3eb3bddb12b
 	github.com/go-logr/zapr v1.3.0
+	github.com/google/uuid v1.6.0
 	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/stretchr/testify v1.10.0
 	github.com/valkey-io/valkey-go v1.0.57
@@ -33,7 +34,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gnostic-models v0.6.9 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect


### PR DESCRIPTION
this allows for `zap.Object` or `zap.Inline` instead of `Zap.Any`